### PR TITLE
Pass models as callable function to JqGridArrayAction

### DIFF
--- a/actions/JqGridArrayAction.php
+++ b/actions/JqGridArrayAction.php
@@ -40,7 +40,7 @@ class JqGridArrayAction extends Action
 {
     use JqGridActionTrait;
 
-    /** @var array $models ArrayDataProvider's models property */
+    /** @var array|callable $models ArrayDataProvider's models property */
     public $models;
 
     public function run()
@@ -65,6 +65,10 @@ class JqGridArrayAction extends Action
      */
     protected function requestAction($requestData)
     {
+        if (is_callable($this->models)) {
+            $this->models = call_user_func($this->models);
+        }
+        
         $dataProvider = new ArrayDataProvider(
             [
                 'allModels' => $this->models,


### PR DESCRIPTION
Hey,
Using your example for JqGridArrayAction I faced that query for 'models' is executed for each controller action. I believe it is reasonable to add an abbility to pass models as callable function to avoid executing extra queries, my case example:
```
        return [
            'jqgrid' => [
                'class' => JqGridArrayAction::className(),
                'models' => function () {
                    $filerModel = new FilterForm();
                    return $filerModel->search(app()->request->queryParams);
                }
            ],
        ];
```
Perhaps you'd like to add an example to class comment as well.