### PR TITLE
Support jqGrid inline cell editing

### DIFF
--- a/actions/JqGridActiveAction.php
+++ b/actions/JqGridActiveAction.php
@@ -180,11 +180,13 @@ class JqGridActiveAction extends Action
         }
 
         $relationColumns = [];
+        $recordAttributes = [];
         foreach ($this->columns as $column) {
             if (isset($requestData[$column])) {
                 if ((strpos($column, '.')) === false) {
                     // no relation
                     $record->$column = $requestData[$column];
+                    $recordAttributes[] = $column;
                 } else {
                     // with relation
                     preg_match('/(.+)\.([^\.]+)/', $column, $matches);
@@ -201,6 +203,7 @@ class JqGridActiveAction extends Action
             if (count($relationColumns)) {
                 foreach ($relationColumns as $relationName => $columns) {
                     $relation = $record;
+                    $relationAttributes = [];
                     foreach (explode('.', $relationName) as $relationPart) {
                         $relation = $relation->$relationPart;
                         if ($relation === null) {
@@ -213,8 +216,9 @@ class JqGridActiveAction extends Action
 
                     foreach ($columns as $column) {
                         $relation->$column['column'] = $column['value'];
+                        $relationAttributes = [$column['column']];
                     }
-                    if (!$relation->save()) {
+                    if (!$relation->save(true, $relationAttributes)) {
                         $transaction->rollBack();
                         $this->renderModelErrors($relation);
                         return;
@@ -222,7 +226,7 @@ class JqGridActiveAction extends Action
                 }
             }
 
-            if (!$record->save()) {
+            if (!$record->save(true, $recordAttributes)) {
                 $transaction->rollBack();
                 $this->renderModelErrors($record);
                 return;


### PR DESCRIPTION
Hi, I am using jqGrid inline cell editing feature and I have faced a problem that it is not possible to update only the cell that was updated. In my case I have model with 2 invalid attributes. During inline cell editing I am able to fix errors in grid one by one. When I fix 1 attribute and grid tries to save it, I get an error which tells me that another one is invalid, because the `JqGridActiveAction` was implemented to save() the whole model. So I am not able to fix model if it has more than 1 invalid attributes. The PR fixes it by saving only those attributes which was updated.
